### PR TITLE
Enable drag-and-drop for kanban tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,10 @@
-from flask import Flask
+from flask import Flask, send_file
 
 app = Flask(__name__)
 
 @app.route('/')
 def index():
-    return 'Hello, world!'
+    return send_file('index.html')
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,499 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ToDoリスト</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg-color: #f3f4f6;
+            --card-color: #ffffffcc;
+            --text-color: #111827;
+            --accent: #2563eb;
+            --accent-dark: #1d4ed8;
+            --danger: #ef4444;
+            --danger-dark: #dc2626;
+        }
+
+        body {
+            font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--bg-color);
+            color: var(--text-color);
+        }
+
+        .app-shell {
+            width: min(960px, 94vw);
+            background: var(--card-color);
+            backdrop-filter: blur(12px);
+            padding: 28px clamp(16px, 4vw, 32px) 36px;
+            border-radius: 28px;
+            box-shadow: 0 20px 35px rgba(15, 23, 42, 0.15);
+        }
+
+        h1 {
+            margin-top: 0;
+            text-align: center;
+            font-size: clamp(1.6rem, 4vw, 2.6rem);
+            letter-spacing: 0.03em;
+        }
+
+        .input-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            margin-bottom: 28px;
+        }
+
+        .input-row > * {
+            flex: 1;
+        }
+
+        input[type="text"] {
+            padding: 16px 18px;
+            font-size: 1.1rem;
+            border: 2px solid rgba(99, 102, 241, 0.35);
+            border-radius: 16px;
+            outline: none;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .status-input {
+            min-width: 160px;
+            padding: 16px 18px;
+            font-size: 1.05rem;
+            border: 2px solid rgba(99, 102, 241, 0.35);
+            border-radius: 16px;
+            background: rgba(255, 255, 255, 0.9);
+            color: inherit;
+            appearance: none;
+        }
+
+        .status-input:focus {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+            outline: none;
+        }
+
+        input[type="text"]:focus {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+        }
+
+        button {
+            border: none;
+            border-radius: 16px;
+            font-size: 1.1rem;
+            padding: 16px 24px;
+            cursor: pointer;
+            font-weight: 600;
+            transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+        }
+
+        button:active {
+            transform: scale(0.97);
+        }
+
+        .add-btn {
+            background: var(--accent);
+            color: white;
+            min-width: 120px;
+            box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+        }
+
+        .add-btn:hover {
+            background: var(--accent-dark);
+        }
+
+        .board {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 20px;
+        }
+
+        .board-column {
+            background: rgba(255, 255, 255, 0.7);
+            border-radius: 22px;
+            padding: 18px 16px 22px;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 12px 24px rgba(15, 23, 42, 0.08);
+            display: flex;
+            flex-direction: column;
+            min-height: 280px;
+        }
+
+        .board-column.drag-over {
+            outline: 3px dashed rgba(37, 99, 235, 0.5);
+            outline-offset: 6px;
+            background: rgba(255, 255, 255, 0.85);
+        }
+
+        .column-title {
+            font-size: 1.15rem;
+            font-weight: 700;
+            margin: 0 0 16px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .column-title::before {
+            content: '';
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border-radius: 999px;
+            background: var(--accent);
+            opacity: 0.8;
+        }
+
+        .column-title[data-status="in-progress"]::before {
+            background: #f59e0b;
+        }
+
+        .column-title[data-status="done"]::before {
+            background: #10b981;
+        }
+
+        .task-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .task-card {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+            background: rgba(255, 255, 255, 0.9);
+            border-radius: 18px;
+            padding: 16px 18px;
+            box-shadow: 0 10px 18px rgba(15, 23, 42, 0.08);
+            font-size: 1.05rem;
+        }
+
+        .task-card.dragging {
+            opacity: 0.6;
+        }
+
+        .task-main {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+        }
+
+        .task-checkbox {
+            width: 26px;
+            height: 26px;
+            accent-color: var(--accent);
+        }
+
+        .task-text {
+            flex: 1;
+            word-break: break-word;
+            transition: color 0.2s ease, text-decoration-color 0.2s ease;
+        }
+
+        .task-text.completed {
+            text-decoration: line-through;
+            text-decoration-thickness: 0.12em;
+            color: #9ca3af;
+        }
+
+        .task-actions {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .task-status-select {
+            flex: 1;
+            padding: 12px 14px;
+            font-size: 1rem;
+            border-radius: 14px;
+            border: 2px solid rgba(148, 163, 184, 0.6);
+            background: rgba(255, 255, 255, 0.95);
+            appearance: none;
+        }
+
+        .task-status-select:focus {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+            outline: none;
+        }
+
+        .delete-btn {
+            background: var(--danger);
+            color: white;
+            padding: 12px 18px;
+            box-shadow: 0 8px 16px rgba(239, 68, 68, 0.25);
+            border-radius: 14px;
+        }
+
+        .delete-btn:hover {
+            background: var(--danger-dark);
+        }
+
+        .empty-message {
+            text-align: center;
+            color: #6b7280;
+            font-size: 0.95rem;
+            margin-top: 12px;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg-color: #0f172a;
+                --card-color: rgba(15, 23, 42, 0.85);
+                --text-color: #f8fafc;
+            }
+
+            .board-column {
+                background: rgba(30, 41, 59, 0.8);
+            }
+
+            .task-card {
+                background: rgba(30, 41, 59, 0.9);
+            }
+
+            .status-input,
+            .task-status-select {
+                background: rgba(15, 23, 42, 0.9);
+                color: inherit;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .task-actions {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .delete-btn {
+                width: 100%;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main class="app-shell">
+        <h1>My ToDoリスト</h1>
+        <form class="input-row" id="task-form">
+            <input id="task-input" type="text" placeholder="タスクを入力" aria-label="タスク名" required>
+            <select id="task-status" class="status-input" aria-label="タスクの状態">
+                <option value="todo">ToDo</option>
+                <option value="in-progress">進行中</option>
+                <option value="done">完了</option>
+            </select>
+            <button type="submit" class="add-btn">追加</button>
+        </form>
+        <section class="board">
+            <article class="board-column" data-column="todo">
+                <h2 class="column-title" data-status="todo">ToDo</h2>
+                <ul id="todo-list" class="task-list"></ul>
+                <p class="empty-message" data-empty="todo">ToDoのタスクはまだありません。</p>
+            </article>
+            <article class="board-column" data-column="in-progress">
+                <h2 class="column-title" data-status="in-progress">進行中</h2>
+                <ul id="in-progress-list" class="task-list"></ul>
+                <p class="empty-message" data-empty="in-progress">進行中のタスクはまだありません。</p>
+            </article>
+            <article class="board-column" data-column="done">
+                <h2 class="column-title" data-status="done">完了</h2>
+                <ul id="done-list" class="task-list"></ul>
+                <p class="empty-message" data-empty="done">完了したタスクはまだありません。</p>
+            </article>
+        </section>
+    </main>
+
+    <script>
+        const form = document.getElementById('task-form');
+        const input = document.getElementById('task-input');
+        const statusSelect = document.getElementById('task-status');
+
+        const columns = {
+            'todo': {
+                list: document.getElementById('todo-list'),
+                message: document.querySelector('[data-empty="todo"]'),
+                column: document.querySelector('[data-column="todo"]')
+            },
+            'in-progress': {
+                list: document.getElementById('in-progress-list'),
+                message: document.querySelector('[data-empty="in-progress"]'),
+                column: document.querySelector('[data-column="in-progress"]')
+            },
+            'done': {
+                list: document.getElementById('done-list'),
+                message: document.querySelector('[data-empty="done"]'),
+                column: document.querySelector('[data-column="done"]')
+            }
+        };
+
+        const clearColumnHighlights = () => {
+            Object.values(columns).forEach(({ column }) => {
+                column.classList.remove('drag-over');
+            });
+        };
+
+        const updateEmptyState = () => {
+            Object.values(columns).forEach(({ list, message }) => {
+                const hasTasks = list.children.length > 0;
+                message.style.display = hasTasks ? 'none' : 'block';
+            });
+        };
+
+        const createTaskItem = (text, initialStatus) => {
+            const li = document.createElement('li');
+            li.className = 'task-card';
+            li.draggable = true;
+
+            const taskMain = document.createElement('div');
+            taskMain.className = 'task-main';
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.className = 'task-checkbox';
+
+            const span = document.createElement('span');
+            span.textContent = text;
+            span.className = 'task-text';
+
+            taskMain.appendChild(checkbox);
+            taskMain.appendChild(span);
+            li.appendChild(taskMain);
+
+            const actions = document.createElement('div');
+            actions.className = 'task-actions';
+
+            const statusControl = document.createElement('select');
+            statusControl.className = 'task-status-select';
+            statusControl.setAttribute('aria-label', 'タスクの状態を変更');
+
+            const statusOptions = [
+                { value: 'todo', label: 'ToDo' },
+                { value: 'in-progress', label: '進行中' },
+                { value: 'done', label: '完了' }
+            ];
+
+            statusOptions.forEach(({ value, label }) => {
+                const option = document.createElement('option');
+                option.value = value;
+                option.textContent = label;
+                statusControl.appendChild(option);
+            });
+
+            const deleteButton = document.createElement('button');
+            deleteButton.textContent = '削除';
+            deleteButton.className = 'delete-btn';
+            deleteButton.type = 'button';
+
+            actions.appendChild(statusControl);
+            actions.appendChild(deleteButton);
+            li.appendChild(actions);
+
+            const setStatus = (status) => {
+                if (!columns[status]) {
+                    status = 'todo';
+                }
+
+                li.dataset.status = status;
+
+                if (status !== 'done') {
+                    li.dataset.previousStatus = status;
+                }
+
+                if (statusControl.value !== status) {
+                    statusControl.value = status;
+                }
+
+                checkbox.checked = status === 'done';
+                span.classList.toggle('completed', status === 'done');
+                columns[status].list.appendChild(li);
+                updateEmptyState();
+            };
+
+            li.setStatus = setStatus;
+
+            li.addEventListener('dragstart', () => {
+                li.classList.add('dragging');
+            });
+
+            li.addEventListener('dragend', () => {
+                li.classList.remove('dragging');
+                clearColumnHighlights();
+            });
+
+            checkbox.addEventListener('change', () => {
+                if (checkbox.checked) {
+                    setStatus('done');
+                } else {
+                    const fallback = li.dataset.previousStatus || 'todo';
+                    setStatus(fallback === 'done' ? 'todo' : fallback);
+                }
+            });
+
+            statusControl.addEventListener('change', () => {
+                setStatus(statusControl.value);
+            });
+
+            deleteButton.addEventListener('click', () => {
+                li.remove();
+                updateEmptyState();
+            });
+
+            setStatus(initialStatus);
+            return li;
+        };
+
+        Object.entries(columns).forEach(([status, { column }]) => {
+            const handleDragOver = (event) => {
+                event.preventDefault();
+                column.classList.add('drag-over');
+            };
+
+            column.addEventListener('dragover', handleDragOver);
+            column.addEventListener('dragenter', handleDragOver);
+
+            column.addEventListener('dragleave', (event) => {
+                if (!column.contains(event.relatedTarget)) {
+                    column.classList.remove('drag-over');
+                }
+            });
+
+            column.addEventListener('drop', (event) => {
+                event.preventDefault();
+                const dragged = document.querySelector('.task-card.dragging');
+                if (dragged && typeof dragged.setStatus === 'function') {
+                    dragged.setStatus(status);
+                }
+                column.classList.remove('drag-over');
+            });
+        });
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const text = input.value.trim();
+            if (!text) {
+                input.focus();
+                return;
+            }
+
+            const selectedStatus = statusSelect.value;
+            const item = createTaskItem(text, selectedStatus);
+            input.value = '';
+            statusSelect.value = 'todo';
+            input.focus();
+            updateEmptyState();
+        });
+
+        updateEmptyState();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add drag-and-drop styling and markup hooks for each kanban column
- allow tasks to be dragged between columns and update their status automatically
- keep completion checkbox behavior in sync after drag-and-drop moves

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d52e3dad688327b4ba2bee0c0475fd